### PR TITLE
Add additional information to binary listing page

### DIFF
--- a/_data/tags.yaml
+++ b/_data/tags.yaml
@@ -1,5 +1,10 @@
 tags:
   - name: develop
+    tag: develop
     url: https://binaries.spack.io/develop/build_cache/index.json
   - name: v0.18
+    tag: v0.18.0
     url: https://binaries.spack.io/releases/v0.18/build_cache/index.json
+  - name: v0.19
+    tag: v0.19.0
+    url: https://binaries.spack.io/releases/v0.19/build_cache/index.json

--- a/_layouts/cache.html
+++ b/_layouts/cache.html
@@ -54,6 +54,19 @@ button.tag {
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/prism.min.js"></script>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/themes/prism-coy.min.css" rel="stylesheet" type="text/css">
 
+<script type="text/javascript">
+function formatBytes(bytes,decimals) {
+   if (bytes == 0) {
+       return '0 Bytes';
+   }
+   var k = 1024,
+       dm = decimals || 2,
+       sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
+       i = Math.floor(Math.log(bytes) / Math.log(k));
+   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}
+</script>
+
 <div class="container">
 
 <main id="app" class="grid flex-grid" style="justify-content:center; padding-bottom:40px">
@@ -102,7 +115,7 @@ button.tag {
                     class="tag button btn btn-primary btn-xs">{{ s }}</button>{% endfor %}
             </td>
             <td>
-                {{ page.spec_details[forloop.index0].size }}
+                <span class="filesize">{{ page.spec_details[forloop.index0].size }}</span>
             </td>
             <td>
                 <div class="flex">
@@ -128,6 +141,11 @@ $(document).ready(function() {
     $('#cache button.tag').click(function() {
        var filter = $(this).text();
        $('#cache').DataTable().search(filter).draw();
+    });
+
+    $('span.filesize').each(function() {
+       var size = $(this).text();
+       $(this).text(formatBytes(size));
     });
 });    
 </script>

--- a/_layouts/cache.html
+++ b/_layouts/cache.html
@@ -10,7 +10,7 @@ layout: default
 {% assign emoji = emojis | sample: 2 %}
 
 <p style="color:white"><strong><a href="{{ site.baseurl }}/"><<</a> This package has {{ page.spec_names | size }}</strong> specs in the build cache! {{ emoji[0] }}</p>
-<p style="color:white"><a href="https://packages.spack.io/package.html?name={{ page.title }}">{{ page.title }} on packages.spack.io</a></p>
+<p style="color:white">View <a style="color:white;font-weight:bold" href="https://packages.spack.io/package.html?name={{ page.title }}">{{ page.title }} on packages.spack.io</a></p>
 </header>
 
 

--- a/_layouts/cache.html
+++ b/_layouts/cache.html
@@ -107,7 +107,7 @@ button.tag {
             <td>
                 <div class="flex">
                     <a href="">View Raw Spec</a>
-                    <a href="">Download Tarball</a>
+                    <a href="{{ page.spec_details[forloop.index0].tarball }}">Download Tarball</a>
                 </div>
             </td>
         </tr>

--- a/_layouts/cache.html
+++ b/_layouts/cache.html
@@ -13,10 +13,15 @@ layout: default
 <p style="color:white"><a href="https://packages.spack.io/package.html?name={{ page.title }}">{{ page.title }} on packages.spack.io</a></p>
 </header>
 
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">   
+
+<link rel='stylesheet' href='https://cdn.datatables.net/plug-ins/f2c75b7247b/integration/bootstrap/3/dataTables.bootstrap.css'>
+<link rel='stylesheet' href='https://cdn.datatables.net/responsive/1.0.4/css/dataTables.responsive.css'>
+<link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css'>
+<link rel='stylesheet' href='https://cdn.datatables.net/plug-ins/f2c75b7247b/integration/bootstrap/3/dataTables.bootstrap.css'>
+<link rel='stylesheet' href='https://cdn.datatables.net/responsive/1.0.4/css/dataTables.responsive.css'>
 
 <style>
-#software_filter, #software_length, #software_info {
+#cache_filter, #cache_length, #cache_info {
  color: white;
 }
 .card {
@@ -33,6 +38,9 @@ layout: default
 .btn-primary:hover {
   background-color: gold;
   color: black
+}
+button.tag {
+    margin: 0 4px 4px 0;
 }
 </style>
 </header>
@@ -51,109 +59,79 @@ layout: default
 <main id="app" class="grid flex-grid" style="justify-content:center; padding-bottom:40px">
 <div class="card"><span style="font-size:20px;font-weight:600">{{ page.meta.versions | size }}</span> Versions</div>
 <div class="card"><span style="font-size:20px;font-weight:600">{{ page.meta.compilers | size }}</span> Compilers</div>
-<div class="card"><span style="font-size:20px;font-weight:600">{{ page.meta.arches | size }}</span> Arches</div>
+<div class="card"><span style="font-size:20px;font-weight:600">{{ page.meta.arches | size }}</span> Architectures</div>
 </main>
 
+<a class="button reset filter-reset" onclick="$('#cache').DataTable().search('').draw()" style='float:right;padding-bottom:5px' href="#">reset</a></li>
 
-<div class="row" style="padding-bottom:10px">
-   <div class="col-md-12">
-   <div class="row-fluid text-left">
-    <span class="clearable">
-        <input title="Search is over the full spec name and not the full content, which is loaded on demand." type="text" id="filter" placeholder="Type to Search" />
-        <span class="icon_clear" style="color:white; padding:5px; cursor:pointer"><i class="fas fa-undo"></i></span>
-    </span>
-    {% for v in page.meta.versions %}<button class="tag button btn btn-primary btn-sm">{{ v }}</button>{% endfor %}
-    {% for c in page.meta.compilers %}<button class="tag button btn btn-primary btn-sm">{{ c }}</button>{% endfor %}
-    {% for a in page.meta.arches %}<button class="tag button btn btn-primary btn-sm">{{ a }}</button>{% endfor %}
-  </div>
-   </div>
-</div>
+<table id="cache" class="table table-bordered" cellspacing="0" width="100%">
+    <thead>
+        <tr>
+            <th>Hash</th>
+            <th>Versions</th>
+            <th>Compilers</th>
+            <th>Arches</th>
+            <th>Variants</th>
+            <th>Stacks</th>
+            <th>Size</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for spec_name in page.spec_names %}
+        <tr>
+            <td>
+                {{ page.spec_details[forloop.index0].hash }}
+            </td>
+            <td>
+                {% for v in page.spec_details[forloop.index0].versions %}<button
+                    class="tag button btn btn-primary btn-xs">{{ v }}</button>{% endfor %}
+            </td>
+            <td>
+                <button class="tag button btn btn-primary btn-xs">{{ page.spec_details[forloop.index0].compiler }}</button>
+            </td>
+            <td>
+                <button class="tag button btn btn-primary btn-xs">{{ page.spec_details[forloop.index0].architecture }}</button>
+            </td>
+            <td>
+                {% for v in page.spec_details[forloop.index0].variants %}<button
+                    class="tag button btn btn-primary btn-xs">{{ v }}</button>{% endfor %}
+            </td>
+            <td>
+                {% for s in page.spec_details[forloop.index0].stacks %}<button
+                    class="tag button btn btn-primary btn-xs">{{ s }}</button>{% endfor %}
+            </td>
+            <td>
+                {{ page.spec_details[forloop.index0].size }}
+            </td>
+            <td>
+                <div class="flex">
+                    <a href="">View Raw Spec</a>
+                    <a href="">Download Tarball</a>
+                </div>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
 
-<div class="row">
-</div>
 
-<div class="row"><div class="col-md-12">
-<div class="accordion" id="accordionSpecs">
-{% for spec_name in page.spec_names %}<div class="accordion-item">
-    <h2 class="accordion-header" id="heading-{{ forloop.index0 }}">
-      <div class="row"><div class="col-md-12">
-      <button data-fulltext="{{ spec_name }}" class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ forloop.index0 }}" aria-expanded="true" aria-controls="collapse-{{ forloop.index0 }}">
-        <strong>{{ spec_name | truncate: 140}}</strong>
-      </button></div> 
-      </div>
-    </h2>
-    <div id="collapse-{{ forloop.index0 }}" class="accordion-collapse collapse" aria-labelledby="heading" data-bs-parent="#accordionSpecs" data-spec="{{ page.spec_files[forloop.index0]}}" data-id="{{ forloop.index0 }}">
-      <div class="accordion-body">
-       <pre><code class="language-javascript" id="code-{{ forloop.index0 }}">
-        {{ page.spec_files[forloop.index0] }}
-       </code></pre>
-      </div>
-    </div>
-  </div>
-{% endfor %}
-</div>
-</div></div>
 </div>
 
 {% include footer.html %}
 
 <script>
-// Load and show the spec on demand
-$('#accordionSpecs').on('show.bs.collapse', function (e) {
-
-    // Only load if we haven't loaded yet!
-    if (!$(e.target).attr('data-loaded')) {
-        spec_file = "../" + $(e.target).attr("data-spec");
-        code_id = "#code-" + $(e.target).attr("data-id");
-        $.getJSON(spec_file, function(data) {
-            $(code_id).html(JSON.stringify(data, null, 2))
-        
-            // Mark that we've loaded it
-            $(e.target).attr('data-loaded', true)
-        });
-    }
-})
-
-function search(term) {
-    $('.accordion-button').each(function() {
-        var cellText = $(this).attr("data-fulltext").toLowerCase();
-        var accordion = $('#accordianSpecs');
-        accordion.find('.collapse.in').hide();
-        if (cellText.indexOf(term) >= 0) {
-            $(this).parent().show();
-        } else {
-            $(this).parent().hide();
-        }
-    });
-}
-
-function reset() {
-    $('.accordion-button').each(function() {
-        var accordion = $('#accordianSpecs');
-        accordion.find('.collapse.in').show();
-        $(this).parent().show();
-    });
-}
-
-// Clicking a tag does the search
-$(".tag").click(function(){
-  var term = $(this).text()
-  search(term)
-})
-
 // Allow searching titles of entries
 $(document).ready(function() {
+    $('#cache').DataTable({pageLength: 50});
 
-    // Reset the list
-    $('.icon_clear').click(function() {        
-        reset()
-    });
-    
-    $('#filter').keyup(function(event) {
-        var unicode = event.charCode ? event.charCode : event.keyCode;
-        if (unicode == 27) { $(this).val(""); }
-        var searchKey = $(this).val().toLowerCase();
-        search(searchKey)
+    $('#cache button.tag').click(function() {
+       var filter = $(this).text();
+       $('#cache').DataTable().search(filter).draw();
     });
 });    
 </script>
+
+<script src='https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js'></script>
+<script src='https://cdn.datatables.net/plug-ins/f2c75b7247b/integration/bootstrap/3/dataTables.bootstrap.js'></script>
+<script src='https://cdn.datatables.net/responsive/1.0.4/js/dataTables.responsive.js'></script>

--- a/_layouts/cache.html
+++ b/_layouts/cache.html
@@ -10,6 +10,7 @@ layout: default
 {% assign emoji = emojis | sample: 2 %}
 
 <p style="color:white"><strong><a href="{{ site.baseurl }}/"><<</a> This package has {{ page.spec_names | size }}</strong> specs in the build cache! {{ emoji[0] }}</p>
+<p style="color:white"><a href="https://packages.spack.io/package.html?name={{ page.title }}">{{ page.title }} on packages.spack.io</a></p>
 </header>
 
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">   

--- a/_layouts/cache.html
+++ b/_layouts/cache.html
@@ -50,6 +50,7 @@ layout: default
 <main id="app" class="grid flex-grid" style="justify-content:center; padding-bottom:40px">
 <div class="card"><span style="font-size:20px;font-weight:600">{{ page.meta.versions | size }}</span> Versions</div>
 <div class="card"><span style="font-size:20px;font-weight:600">{{ page.meta.compilers | size }}</span> Compilers</div>
+<div class="card"><span style="font-size:20px;font-weight:600">{{ page.meta.arches | size }}</span> Arches</div>
 </main>
 
 
@@ -62,6 +63,7 @@ layout: default
     </span>
     {% for v in page.meta.versions %}<button class="tag button btn btn-primary btn-sm">{{ v }}</button>{% endfor %}
     {% for c in page.meta.compilers %}<button class="tag button btn btn-primary btn-sm">{{ c }}</button>{% endfor %}
+    {% for a in page.meta.arches %}<button class="tag button btn btn-primary btn-sm">{{ a }}</button>{% endfor %}
   </div>
    </div>
 </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -29,7 +29,6 @@ hide_footer: true
   font-weight:600;
   display: grid;
 }
-}
 </style>
 </header>
 

--- a/_layouts/table.html
+++ b/_layouts/table.html
@@ -5,6 +5,17 @@ layout: default
 <header>
 
 <h1 id="title" style="color:white"><img style="width:100px;padding-right:10px" src="{{ site.baseurl }}/assets/img/spack-logo.svg" />Spack Build Cache <small>{{ page.tag }}</small></h1>
+
+<div class="callout" style="color:white">
+  <p>To add the cache, run the following command:</p>
+  <pre>
+    spack mirror add spack-build-cache-{{ page.tag }} https://binaries.spack.io/releases/{{ page.tag }}
+    spack buildcache keys --install --trust
+  </pre>
+  <p>This command will add the build cache to your Spack configuration, allowing you to access pre-built packages for faster installation.</p>
+  <p>For more information, please visit the <a href="https://spack-tutorial.readthedocs.io/en/latest/tutorial_binary_cache.html">Spack documentation on mirrors</a>.</p>
+</div>
+
 <link rel='stylesheet' href='https://cdn.datatables.net/plug-ins/f2c75b7247b/integration/bootstrap/3/dataTables.bootstrap.css'>
 <link rel='stylesheet' href='https://cdn.datatables.net/responsive/1.0.4/css/dataTables.responsive.css'>
 </header>
@@ -24,6 +35,10 @@ layout: default
   width:120px !important;
   min-height: 100px !important;
   cursor: default !important;
+
+.callout pre {
+    text-align: left;
+    white-space: pre-line;
 }
 }
 </style>

--- a/_layouts/table.html
+++ b/_layouts/table.html
@@ -47,6 +47,7 @@ layout: default
             <th>Package</th>
             <th>Versions</th>
             <th>Compilers</th>
+            <th>Arches</th>
         </tr>
   </thead>      
 </table>
@@ -109,7 +110,19 @@ $('#software').DataTable( {
          return compilers
       },
       targets: 0,
-    }
+    },
+    {data: "arches",
+      render: function ( data, type, row ) {
+         var arches = ""
+         if(data.length > 0) {
+           $.each(data, function(i, e){
+              arches += "<button onclick=$('#software').DataTable().search('"+ e +"').draw(); class='tag button btn btn-primary btn-xs'>" + e + "</button> ";
+           })
+         }
+         return arches
+      },
+      targets: 0,
+     }
   ]
 });
 });

--- a/_layouts/table.html
+++ b/_layouts/table.html
@@ -36,6 +36,9 @@ layout: default
     text-align: left;
     white-space: pre-line;
 }
+
+button.tag {
+    margin-bottom: 4px;
 }
 </style>
 </header>

--- a/_layouts/table.html
+++ b/_layouts/table.html
@@ -31,10 +31,6 @@ layout: default
 #software_filter, #software_length, #software_info {
  color: white;
 }
-.card {
-  width:120px !important;
-  min-height: 100px !important;
-  cursor: default !important;
 
 .callout pre {
     text-align: left;
@@ -45,11 +41,6 @@ layout: default
 </header>
 
 <div class="container">
-<main id="app" class="grid flex-grid" style="justify-content:center;">
-<div class="card"><span style="font-size:20px;font-weight:600">{{ site.data.meta[page.tag].count }}</span> Entries</div>
-<div class="card"><span style="font-size:20px;font-weight:600">{{ site.data.meta[page.tag].compiler_count }}</span> Compilers</div>
-<div class="card"><span style="font-size:20px;font-weight:600">{{ site.data.meta[page.tag].parameter_count }}</span> Variants</div>
-</main>
 
 <a class="button reset filter-reset" onclick="$('#software').DataTable().search('').draw()" style='float:right;padding-bottom:5px' href="#">reset</a></li>
 
@@ -88,6 +79,9 @@ data = data.filter(filterTag){% endif %}
 console.log(data)
 
 $('#software').DataTable( {
+  language: {
+      lengthMenu: "Show _MENU_ entries of " + data.length,
+  },
   data: data,
   pageLength: 50,
   columns: [
@@ -144,7 +138,7 @@ $('#software').DataTable( {
 
 })
 </script>
-<script src='https://cdn.datatables.net/1.10.5/js/jquery.dataTables.min.js'></script>
+<script src='https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js'></script>
 <script src='https://cdn.datatables.net/plug-ins/f2c75b7247b/integration/bootstrap/3/dataTables.bootstrap.js'></script>
 <script src='https://cdn.datatables.net/responsive/1.0.4/js/dataTables.responsive.js'></script>
 </body>

--- a/_layouts/table.html
+++ b/_layouts/table.html
@@ -92,12 +92,14 @@ $('#software').DataTable( {
       render: function ( data, type, row ) { return "<a href='" + row['rel'] + "'>" + data +"</a>";},
       targets: 1,
     },
-    {data: 'specs'},
+    {data: 'specs', orderable: false},
     { data: "tag",
       render: function ( data, type, row ) { return row['tag']},
+      orderable: false,
     },
     { data: null,
-      render: function ( data, type, row ) { return "<a href='" + row['url']  + "' target='_blank'> View Package </a>"},   
+      render: function ( data, type, row ) { return "<a href='" + row['url']  + "' target='_blank'> View Package </a>"},
+      orderable: false,
     },
     {data: 'versions',
       render: function ( data, type, row ) { 
@@ -110,6 +112,7 @@ $('#software').DataTable( {
          return versions
       },
       targets: 0,    
+      orderable: false,
     },
     {data: "compilers", 
       render: function ( data, type, row ) { 
@@ -122,6 +125,7 @@ $('#software').DataTable( {
          return compilers
       },
       targets: 0,
+      orderable: false,
     },
     {data: "arches",
       render: function ( data, type, row ) {
@@ -134,6 +138,7 @@ $('#software').DataTable( {
          return arches
       },
       targets: 0,
+      orderable: false,
      }
   ]
 });

--- a/_layouts/table.html
+++ b/_layouts/table.html
@@ -79,7 +79,6 @@ function filterTag(value) {
   return value['tag'] == "{{ page.tag }}"
 }
 data = data.filter(filterTag){% endif %}
-console.log(data)
 
 $('#software').DataTable( {
   language: {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -228,6 +228,7 @@ article {
 .site-footer {
    padding: 60px;
    color: white;
+   text-align: center;
 }
 
 .site-footer a {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -119,7 +119,7 @@ body > header h2 {
   line-height: 2rem;
 }
 body > header p {
-  font-size: 1.25rem;
+  font-size: 1.75rem;
   line-height: 1.75rem;
 }
 

--- a/generate_cache.py
+++ b/generate_cache.py
@@ -24,6 +24,7 @@ import yaml
 import spack.database
 import spack.repo
 import spack.spec
+import spack.binary_distribution
 
 here = os.getcwd()
 db_root = os.path.join(here, "spack-db")
@@ -144,6 +145,7 @@ def write_cache_entries(name, specs, hash_stacks):
                     "variants": list(spec.variants.keys()),
                     "stacks": list(hash_stacks[spec._hash]),
                     "size": binary_size(spec),
+                    "tarball": spack.binary_distribution.tarball_name(spec, '.spack'),
                 }
             )
             spec_names.append("'" + str(spec) + "'")

--- a/generate_cache.py
+++ b/generate_cache.py
@@ -53,7 +53,7 @@ def write_cache_entries(name, specs):
     for package_name, speclist in specs.items():
 
         # Keep a set of summary metrics for a spec
-        metrics = {"versions": set(), "compilers": set()}
+        metrics = {"versions": set(), "compilers": set(), "arches": set()}
 
         package_dir = os.path.join(here, "_cache", name, package_name)
         if not os.path.exists(package_dir):
@@ -61,6 +61,7 @@ def write_cache_entries(name, specs):
         spec_files = []
         spec_names = []
         for i, spec in enumerate(speclist):
+            metrics["arches"].add(str(spec.architecture))
             metrics["versions"].add(str(spec.version))
             metrics["compilers"].add(str(spec.compiler))
             spec_name = "spec-%s.json" % i
@@ -68,6 +69,7 @@ def write_cache_entries(name, specs):
             write_json(spec.to_dict(), spec_file)
             spec_files.append(spec_name)
             spec_names.append("'" + str(spec) + "'")
+        metrics["arches"] = sorted(list(metrics["arches"]))
         metrics["versions"] = sorted(list(metrics["versions"]))
         metrics["compilers"] = sorted(list(metrics["compilers"]))
         render = template % (

--- a/generate_cache.py
+++ b/generate_cache.py
@@ -40,9 +40,14 @@ categories: [package, %s]
 meta: %s
 spec_files: 
  - %s
+spec_details: %s
 spec_names:
  - %s
 ---"""
+
+def binary_size(spec):
+    # TODO: fetch at build time
+    return 1024 * 1024
 
 
 def write_cache_entries(name, specs):
@@ -60,6 +65,7 @@ def write_cache_entries(name, specs):
             os.makedirs(package_dir)
         spec_files = []
         spec_names = []
+        spec_details = []
         for i, spec in enumerate(speclist):
             metrics["arches"].add(str(spec.architecture))
             metrics["versions"].add(str(spec.version))
@@ -68,6 +74,16 @@ def write_cache_entries(name, specs):
             spec_file = os.path.join(package_dir, spec_name)
             write_json(spec.to_dict(), spec_file)
             spec_files.append(spec_name)
+            spec_details.append(
+                {
+                    "hash": spec._hash,
+                    "compiler": str(spec.compiler),
+                    "versions": [str(v) for v in spec.versions],
+                    "arches": str(spec.architecture),
+                    "variants": list(spec.variants.keys()),
+                    "size": binary_size(spec),
+                }
+            )
             spec_names.append("'" + str(spec) + "'")
         metrics["arches"] = sorted(list(metrics["arches"]))
         metrics["versions"] = sorted(list(metrics["versions"]))
@@ -77,6 +93,7 @@ def write_cache_entries(name, specs):
             name,
             json.dumps(metrics),
             " - ".join([x + "\n" for x in spec_files]).strip(),
+            json.dumps(spec_details),
             " - ".join([x + "\n" for x in spec_names]).strip(),
         )
         md_file = os.path.join(package_dir, "specs.md")

--- a/generate_cache.py
+++ b/generate_cache.py
@@ -140,7 +140,7 @@ def write_cache_entries(name, specs, hash_stacks):
                     "hash": spec._hash,
                     "compiler": str(spec.compiler),
                     "versions": [str(v) for v in spec.versions],
-                    "arches": str(spec.architecture),
+                    "architecture": str(spec.architecture),
                     "variants": list(spec.variants.keys()),
                     "stacks": list(hash_stacks[spec._hash]),
                     "size": binary_size(spec),

--- a/generate_cache.py
+++ b/generate_cache.py
@@ -6,12 +6,20 @@
 # Usage:
 # python generate_cache.py
 
-
+from collections import defaultdict
+from contextlib import contextmanager
+from functools import lru_cache
+from pathlib import Path
+from typing import Set
+import git
 import json
-import yaml
-import sys
+import os
 import os
 import requests
+import shutil
+import sys
+import tempfile
+import yaml
 
 import spack.database
 import spack.repo
@@ -50,15 +58,67 @@ def binary_size(spec):
     return 1024 * 1024
 
 
-def write_cache_entries(name, specs):
+@contextmanager
+def git_repo_context(repo_url):
+    """
+    A context manager that clones a Git repository into a temporary directory, and
+    provides a reference to the repository object for use within the context.
+
+    :param repo_url: The URL of the repository to clone.
+    """
+    temp_dir = tempfile.mkdtemp()
+
+    try:
+        repo = git.Repo.clone_from(repo_url, temp_dir)
+        yield repo
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+@lru_cache
+def get_version_stacks(repo: git.Repo, tag: str) -> Set[str]:
+    repo.git.checkout(tag)
+    stacks_dir = (
+        Path(repo.working_dir)
+        / "share"
+        / "spack"
+        / "gitlab"
+        / "cloud_pipelines"
+        / "stacks"
+    )
+    return set(os.listdir(stacks_dir))
+
+def get_hash_stacks(repo: git.Repo, tag: str) -> dict[str, set[str]]:
+    hash_stacks = defaultdict(set)
+
+    for stack in get_version_stacks(repo, tag):
+        url = f'https://binaries.spack.io/{tag}/{stack}/build_cache/index.json'
+        r = requests.get(url)
+        if r.status_code == 404:
+            print(f'No build cache for {tag} {stack} ({url})')
+            continue
+        else:
+            r.raise_for_status()
+
+        for hash in r.json()['database']['installs'].keys():
+            hash_stacks[hash].add(stack)
+
+    return hash_stacks
+
+
+def write_cache_entries(name, specs, hash_stacks):
     """
     Given a named list of specs, write markdown and json to cache output directory.
     """
     # For each spec, write to the _cache folder
     for package_name, speclist in specs.items():
-
         # Keep a set of summary metrics for a spec
-        metrics = {"versions": set(), "compilers": set(), "arches": set()}
+        metrics = {
+            "versions": set(),
+            "compilers": set(),
+            "arches": set(),
+            "stacks": set(),
+        }
 
         package_dir = os.path.join(here, "_cache", name, package_name)
         if not os.path.exists(package_dir):
@@ -70,6 +130,7 @@ def write_cache_entries(name, specs):
             metrics["arches"].add(str(spec.architecture))
             metrics["versions"].add(str(spec.version))
             metrics["compilers"].add(str(spec.compiler))
+            metrics["stacks"] |= hash_stacks[spec._hash]
             spec_name = "spec-%s.json" % i
             spec_file = os.path.join(package_dir, spec_name)
             write_json(spec.to_dict(), spec_file)
@@ -81,6 +142,7 @@ def write_cache_entries(name, specs):
                     "versions": [str(v) for v in spec.versions],
                     "arches": str(spec.architecture),
                     "variants": list(spec.variants.keys()),
+                    "stacks": list(hash_stacks[spec._hash]),
                     "size": binary_size(spec),
                 }
             )
@@ -88,6 +150,7 @@ def write_cache_entries(name, specs):
         metrics["arches"] = sorted(list(metrics["arches"]))
         metrics["versions"] = sorted(list(metrics["versions"]))
         metrics["compilers"] = sorted(list(metrics["compilers"]))
+        metrics["stacks"] = sorted(list(metrics["stacks"]))
         render = template % (
             package_name,
             name,
@@ -193,29 +256,37 @@ def main():
     # Metadata file will store all versions
     meta = {}
     tags = read_yaml(tags_file)
-    for entry in tags.get("tags", []):
-        if "name" not in entry or "url" not in entry:
-            sys.exit(f"Malformed entry {entry} missing url or name key.")
-        name = entry["name"]
-        url = entry["url"]
-        print(f"Parsing cache for {name}")
+    with git_repo_context("https://github.com/spack/spack") as repo:
+        for entry in tags.get("tags", []):
+            if "name" not in entry or "url" not in entry or "tag" not in entry:
+                sys.exit(f"Malformed entry {entry} missing url or tag or name.")
+            name = entry["name"]
+            tag = entry["tag"]
+            url = entry["url"]
+            print(f"Parsing cache for {name}")
 
-        # Create spack database and load specs
-        index, specs = load_spack_db(name, url)
+            # Create spack database and load specs
+            print('Loading spack db')
+            index, specs = load_spack_db(name, url)
 
-        # Update metadata file
-        meta[name] = {
-            "version": index["database"]["version"],
-            "count": len(index["database"]["installs"]),
-        }
-        del index
+            print('Getting hash stacks')
+            hash_stacks = get_hash_stacks(repo, tag)
 
-        # Get metadata for specs
-        updates = get_specs_metadata(specs)
-        meta[name].update(updates)
+            # Update metadata file
+            meta[name] = {
+                "version": index["database"]["version"],
+                "count": len(index["database"]["installs"]),
+            }
+            del index
 
-        # Write jekyll files
-        write_cache_entries(name, specs)
+            # Get metadata for specs
+            print('Getting specs metadata')
+            updates = get_specs_metadata(specs)
+            meta[name].update(updates)
+
+            # Write jekyll files
+            print('Writing jekyll files')
+            write_cache_entries(name, specs, hash_stacks)
 
     # Create the "all" group
     meta["all"] = {"version": "all", "count": 0}

--- a/pages/api/data.json
+++ b/pages/api/data.json
@@ -2,12 +2,13 @@
 layout: null
 permalink: /api/data.json
 ---
-[{% for entry in site.cache %}{ {% assign versions = entry.meta.versions  %}{% assign compilers = entry.meta.compilers %}
+[{% for entry in site.cache %}{ {% assign versions = entry.meta.versions  %}{% assign compilers = entry.meta.compilers %}{% assign arches = entry.meta.arches %}
         "uid": "{{ entry.title }}",
         "tag": "{{ entry.categories[1] }}",
         "url": "https://packages.spack.io/package.html?name={{ entry.title }}",
         "rel": "{{ site.baseurl }}{{ entry.url }}",
         "versions": [{% for v in versions %}"{{ v }}"{% if forloop.last %}{% else %},{% endif %}{% endfor %}],
         "compilers": [{% for c in compilers %}"{{ c }}"{% if forloop.last %}{% else %},{% endif %}{% endfor %}],
+        "arches": [{% for a in arches %}"{{ a }}"{% if forloop.last %}{% else %},{% endif %}{% endfor %}],
         "specs": {{ entry.spec_files | size }}
     }{% if forloop.last %}{% else %},{% endif %}{% endfor %}]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 pyaml
+gitpython


### PR DESCRIPTION
This PR adds some UI enhancements to the package and binary listing pages.
- Added instructions for adding a mirror (these probably need to be ironed out)
- Added the architecture to package and binary listing pages
- Added the hash, architectures, stacks, and variants to the binary listing page
- Added cross-linking from binary listing to packages.spack.io

Todo
- [ ] Collect binary sizes from S3 (right now I'm using fake data until I have AWS access)
- [ ] Use S3 bucket listing to populate the releases dynamically
- [ ] Update GitHub actions to have S3 read access, probably using https://github.com/aws-actions/configure-aws-credentials?

Some screenshots (these don't reflect the full data since I was building on a subset): 

![Screenshot 2023-04-21 at 11-08-29 Spack Build Cache](https://user-images.githubusercontent.com/608229/233671411-506092a5-5f39-469a-a0ea-4f3819aa1d00.png)

![Screenshot 2023-04-21 at 10-46-44 Spack Build Cache](https://user-images.githubusercontent.com/608229/233668092-f1947bfb-a72d-4cc4-83ae-1b5f0354f57f.png)



