### PR TITLE
Remove jekyll-feed and jekyll-paginate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,5 @@ gem 'kramdown-parser-gfm'
 gem 'webrick'
 
 group :jekyll_plugins do
-    gem "jekyll-feed", "~> 0.6"
     gem "jekyll-sitemap"
-    gem "jekyll-paginate"
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,9 +33,6 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-feed (0.17.0)
-      jekyll (>= 3.7, < 5.0)
-    jekyll-paginate (1.1.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-sitemap (1.4.0)
@@ -77,8 +74,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  jekyll-feed (~> 0.6)
-  jekyll-paginate
   jekyll-sitemap
   kramdown
   kramdown-parser-gfm

--- a/_config.yml
+++ b/_config.yml
@@ -15,8 +15,6 @@ github_repo: cache.spack.io
 
 plugins:
   - jekyll-sitemap
-  - jekyll-paginate
-  - jekyll-feed
 
 exclude:
   - Gemfile


### PR DESCRIPTION
This removes jekyll plugins we aren't using.