### PR TITLE
Support keeping old refs around after the layout change

### DIFF
--- a/.github/workflows/update-ui.yaml
+++ b/.github/workflows/update-ui.yaml
@@ -13,14 +13,14 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v3
     - name: Clone development branch of spack
-      run: git clone https://github.com/spack/spack /opt/spack    
+      run: git clone https://github.com/spack/spack /opt/spack
     - name: Run update script
       run: |
          export PATH=/opt/spack/bin:$PATH
          pip install -r requirements.txt
          # make directories first to ensure they exist to prevent find from failing
          mkdir -p _cache pages/tags _data
-         find _cache pages/tags _data -mindepth 1 -delete && spack python generate_cache.py
+         spack python generate_cache.py
 
     - name: Push Results
       run: |

--- a/generate_cache.py
+++ b/generate_cache.py
@@ -229,9 +229,19 @@ def get_specs_metadata(specs: dict[str, list[spack.spec.Spec]]) -> dict:
     return updates
 
 
+def load_existing_metadata() -> dict[str, dict]:
+    meta_path = here / "_data" / "meta.yaml"
+    try:
+        with open(meta_path) as fd:
+            return yaml.safe_load(fd.read())
+    except Exception:
+        print("No pre-existing metadata could be read")
+        return {}
+
+
 def main():
     # Metadata file will store all versions
-    meta: dict[str, dict] = {}
+    meta: dict[str, dict] = load_existing_metadata()
     tags = []
 
     tags_dir = here / "pages" / "tags"

--- a/generate_cache.py
+++ b/generate_cache.py
@@ -131,7 +131,7 @@ def write_cache_entries(name, specs, hash_stacks):
                     "platform": spec.architecture.platform,
                     "target": spec.architecture.target.name,
                     "variants": [str(v) for v in spec.variants.values()],
-                    "stacks": list(hash_stacks[spec._hash]),
+                    "stacks": sorted(list(hash_stacks[spec._hash])),
                     "size": binary_size(spec),
                     "tarball": tarball_url,
                 }
@@ -145,8 +145,8 @@ def write_cache_entries(name, specs, hash_stacks):
         render = template % (
             package_name,
             name,
-            json.dumps(metrics),
-            json.dumps(spec_details),
+            json.dumps(metrics, sort_keys=True),
+            json.dumps(spec_details, sort_keys=True),
         )
         md_file = os.path.join(package_dir, "specs.md")
         with open(md_file, "w") as fd:

--- a/generate_cache.py
+++ b/generate_cache.py
@@ -28,6 +28,7 @@ here = Path(os.getcwd())
 db_root = here / "spack-db"
 
 INDEX_URL = "https://binaries.spack.io/cache_spack_io_index.json"
+MUTABLE_REFS = ["develop"]
 
 # Template for cache data
 template = """---
@@ -235,8 +236,6 @@ def main():
 
     tags_dir = here / "pages" / "tags"
     tags_dir.mkdir(parents=True, exist_ok=True)
-    for f in tags_dir.iterdir():
-        f.unlink()
 
     for name, stacks in get_build_cache_index().items():
         if not any(s.label == "root" for s in stacks):
@@ -244,6 +243,12 @@ def main():
             continue
 
         url = f"https://binaries.spack.io/{name}/build_cache/index.json"
+
+        cache_path = here / "_cache" / name
+        if os.path.exists(cache_path) and name not in MUTABLE_REFS:
+            print(f"Skip parsing cache for {name}. We already have it, and it is immutable.")
+            continue
+
         print(f"Parsing cache for {name}")
 
         # Create spack database and load specs

--- a/generate_cache.py
+++ b/generate_cache.py
@@ -239,10 +239,20 @@ def load_existing_metadata() -> dict[str, dict]:
         return {}
 
 
+def load_existing_tags() -> list[dict]:
+    tag_path = here / "_data" / "tags.yaml"
+    try:
+        with open(tag_path) as fd:
+            return yaml.safe_load(fd.read())
+    except Exception:
+        print("No pre-existing tags could be read")
+        return []
+
+
 def main():
     # Metadata file will store all versions
     meta: dict[str, dict] = load_existing_metadata()
-    tags = []
+    tags = load_existing_tags()
 
     tags_dir = here / "pages" / "tags"
     tags_dir.mkdir(parents=True, exist_ok=True)
@@ -276,7 +286,15 @@ def main():
         print("Writing jekyll files")
         write_cache_entries(name, specs, hash_stacks)
 
-        tags.append({"name": name, "stacks": sorted([s.label for s in stacks])})
+        tag_entry = {"name": name, "stacks": sorted([s.label for s in stacks])}
+
+        for idx, tag_stacks in enumerate(tags):
+            if tag_stacks["name"] == name:
+                tags[idx] = tag_entry
+                break
+        else:
+            tags.append(tag_entry)
+
         with open(f"pages/tags/{name}.md", "w") as f:
             f.write(tag_page_template % (name, name))
 


### PR DESCRIPTION
The goal of this PR is to prepare for an upcoming [change](https://github.com/spack/spack/pull/48713) to spack buildcache layout.  Rather than have this repo maintain code to sift through buildcaches of two different layouts, the idea is to get it to stop re-processing the same immutable stacks on a daily basis, ahead of making the change to support the new buildcache layout.  This will serve two purposes:

1. Allow the website to maintain listings for old spack refs that are unchanging anyway (tagged releases and develop snapshots), both now and after we update spack and the cache indexer to the new buildcache layout. 
2. Avoid a lot of unnecessary fetching of spec files after the layout update.  Once we update to the new buildcache layout, we can no longer directly compute the url to a tarball from just the concrete spec and mirror url.  Instead, it will at that point be necessary to retrieve the spec metadata (`.spec.json.sig` or `spec.json`) file for each spec, in order to read the tarball checksum first.  In contrast, currently the website generation process only needs to fetch the buildcache index of each top-level or stack-specific mirror, so the layout change will significantly increase the number of files we have to fetch per-ref.

This change is accomplished by introducing a `MUTABLE_REFS` list, and avoiding processing for any refs that already exist in the repo and do not appear in that list.  In order to avoid losing information, we must now load some of the existing information from `cache/` and `_data/` in order to preserve data for refs we skip processing.

One consequence of this change is that removal of old tags/refs will no longer be sufficient to remove the corresponding material from the website.  Instead we can do the following when we are ready to remove the old refs that still have the old buildcache layout:

- merge a PR here to remove data associated with those refs from `_cache/`, `_data/`, and  `pages/tags/`
- remove those refs from the mirror bucket
- remove (or regenerate) the `cache_spack_io_index.json` from the root of the bucket

We can merge this now or soon and keep an eye on the github actions to make sure changes to `develop` and new snapshots are properly processed, while old refs are left untouched.  Then we will need a subsequent PR to handle the layout change, to be timed appropriately with merging the spack PR linked above.