### PR TITLE
Fix stack selection styling

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -38,7 +38,7 @@
                     <label class="label floating">
                         <span class="label-text-alt text-gray-400 text-[10px]">Stack</span>
                     </label>
-                    <button class="custom-select !select-sm w-48" @click="stackIsOpen = !stackIsOpen">
+                    <button class="custom-select !select-sm stack-select mr-1" @click="stackIsOpen = !stackIsOpen">
                         <span class="selected" x-text="stackSelectedOption"></span>
                     </button>
                 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,5 +1,5 @@
 /*
-! tailwindcss v3.3.3 | MIT License | https://tailwindcss.com
+! tailwindcss v3.3.2 | MIT License | https://tailwindcss.com
 *//*
 1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
 2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
@@ -167,8 +167,6 @@ optgroup,
 select,
 textarea {
   font-family: inherit; /* 1 */
-  font-feature-settings: inherit; /* 1 */
-  font-variation-settings: inherit; /* 1 */
   font-size: 100%; /* 1 */
   font-weight: inherit; /* 1 */
   line-height: inherit; /* 1 */
@@ -303,13 +301,6 @@ ul,
 menu {
   list-style: none;
   margin: 0;
-  padding: 0;
-}
-
-/*
-Reset default styling for dialogs.
-*/
-dialog {
   padding: 0;
 }
 
@@ -518,6 +509,10 @@ html {
   padding-bottom: 0.5rem;
 }
 
+    .stack-select {
+        min-width: 48px;
+    }
+
     .dataTables_filter {
   display: flex;
   justify-content: flex-end;
@@ -603,9 +598,6 @@ html {
 
     .searchable-badge:active:hover,.searchable-badge:active:focus {
   animation: none;
-}
-
-    .searchable-badge:not(.no-animation):active:hover,.searchable-badge:not(.no-animation):active:focus {
   transform: scale(var(--btn-focus-scale, 0.95));
 }
 
@@ -693,65 +685,65 @@ html {
 }
 
     .btn-group .searchable-badge:not(:first-child):not(:last-child) {
-  border-start-start-radius: 0;
-  border-start-end-radius: 0;
-  border-end-start-radius: 0;
-  border-end-end-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
     .btn-group .searchable-badge:first-child:not(:last-child) {
   margin-top: -0px;
   margin-left: -1px;
-  border-start-start-radius: var(--rounded-btn, 0.5rem);
-  border-start-end-radius: 0;
-  border-end-start-radius: var(--rounded-btn, 0.5rem);
-  border-end-end-radius: 0;
+  border-top-left-radius: var(--rounded-btn, 0.5rem);
+  border-top-right-radius: 0;
+  border-bottom-left-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-right-radius: 0;
 }
 
     .btn-group .searchable-badge:last-child:not(:first-child) {
-  border-start-start-radius: 0;
-  border-start-end-radius: var(--rounded-btn, 0.5rem);
-  border-end-start-radius: 0;
-  border-end-end-radius: var(--rounded-btn, 0.5rem);
+  border-top-left-radius: 0;
+  border-top-right-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: var(--rounded-btn, 0.5rem);
 }
 
     .btn-group-horizontal .searchable-badge:not(:first-child):not(:last-child) {
-  border-start-start-radius: 0;
-  border-start-end-radius: 0;
-  border-end-start-radius: 0;
-  border-end-end-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
     .btn-group-horizontal .searchable-badge:first-child:not(:last-child) {
   margin-top: -0px;
   margin-left: -1px;
-  border-start-start-radius: var(--rounded-btn, 0.5rem);
-  border-start-end-radius: 0;
-  border-end-start-radius: var(--rounded-btn, 0.5rem);
-  border-end-end-radius: 0;
+  border-top-left-radius: var(--rounded-btn, 0.5rem);
+  border-top-right-radius: 0;
+  border-bottom-left-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-right-radius: 0;
 }
 
     .btn-group-horizontal .searchable-badge:last-child:not(:first-child) {
-  border-start-start-radius: 0;
-  border-start-end-radius: var(--rounded-btn, 0.5rem);
-  border-end-start-radius: 0;
-  border-end-end-radius: var(--rounded-btn, 0.5rem);
+  border-top-left-radius: 0;
+  border-top-right-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: var(--rounded-btn, 0.5rem);
 }
 
     .btn-group-vertical .searchable-badge:first-child:not(:last-child) {
   margin-top: -1px;
   margin-left: -0px;
-  border-start-start-radius: var(--rounded-btn, 0.5rem);
-  border-start-end-radius: var(--rounded-btn, 0.5rem);
-  border-end-start-radius: 0;
-  border-end-end-radius: 0;
+  border-top-left-radius: var(--rounded-btn, 0.5rem);
+  border-top-right-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
     .btn-group-vertical .searchable-badge:last-child:not(:first-child) {
-  border-start-start-radius: 0;
-  border-start-end-radius: 0;
-  border-end-start-radius: var(--rounded-btn, 0.5rem);
-  border-end-end-radius: var(--rounded-btn, 0.5rem);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-right-radius: var(--rounded-btn, 0.5rem);
 }
 
     .searchable-badge {
@@ -1937,7 +1929,7 @@ html {
 .tooltip:before {
   position: absolute;
   pointer-events: none;
-  z-index: 999;
+  z-index: 1;
   content: var(--tw-content);
   --tw-content: attr(data-tip);
   max-width: 20rem;
@@ -2052,9 +2044,6 @@ html {
 .btn:active:hover,
   .btn:active:focus {
   animation: none;
-}
-.btn:not(.no-animation):active:hover,
-  .btn:not(.no-animation):active:focus {
   transform: scale(var(--btn-focus-scale, 0.95));
 }
 .btn:hover,
@@ -2788,16 +2777,16 @@ html {
   background-color: hsl(var(--b1) / var(--tw-bg-opacity));
 }
 :where(.table *:first-child) :where(*:first-child) :where(th, td):first-child {
-  border-top-left-radius: var(--rounded-box, 1rem);
+  border-top-left-radius: 0.5rem;
 }
 :where(.table *:first-child) :where(*:first-child) :where(th, td):last-child {
-  border-top-right-radius: var(--rounded-box, 1rem);
+  border-top-right-radius: 0.5rem;
 }
 :where(.table *:last-child) :where(*:last-child) :where(th, td):first-child {
-  border-bottom-left-radius: var(--rounded-box, 1rem);
+  border-bottom-left-radius: 0.5rem;
 }
 :where(.table *:last-child) :where(*:last-child) :where(th, td):last-child {
-  border-bottom-right-radius: var(--rounded-box, 1rem);
+  border-bottom-right-radius: 0.5rem;
 }
 @keyframes toast-pop {
 
@@ -3021,58 +3010,58 @@ html {
   padding-left: 2rem;
 }
 .btn-group .btn:not(:first-child):not(:last-child) {
-  border-start-start-radius: 0;
-  border-start-end-radius: 0;
-  border-end-start-radius: 0;
-  border-end-end-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 .btn-group .btn:first-child:not(:last-child) {
   margin-top: -0px;
   margin-left: -1px;
-  border-start-start-radius: var(--rounded-btn, 0.5rem);
-  border-start-end-radius: 0;
-  border-end-start-radius: var(--rounded-btn, 0.5rem);
-  border-end-end-radius: 0;
+  border-top-left-radius: var(--rounded-btn, 0.5rem);
+  border-top-right-radius: 0;
+  border-bottom-left-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-right-radius: 0;
 }
 .btn-group .btn:last-child:not(:first-child) {
-  border-start-start-radius: 0;
-  border-start-end-radius: var(--rounded-btn, 0.5rem);
-  border-end-start-radius: 0;
-  border-end-end-radius: var(--rounded-btn, 0.5rem);
+  border-top-left-radius: 0;
+  border-top-right-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: var(--rounded-btn, 0.5rem);
 }
 .btn-group-horizontal .btn:not(:first-child):not(:last-child) {
-  border-start-start-radius: 0;
-  border-start-end-radius: 0;
-  border-end-start-radius: 0;
-  border-end-end-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 .btn-group-horizontal .btn:first-child:not(:last-child) {
   margin-top: -0px;
   margin-left: -1px;
-  border-start-start-radius: var(--rounded-btn, 0.5rem);
-  border-start-end-radius: 0;
-  border-end-start-radius: var(--rounded-btn, 0.5rem);
-  border-end-end-radius: 0;
+  border-top-left-radius: var(--rounded-btn, 0.5rem);
+  border-top-right-radius: 0;
+  border-bottom-left-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-right-radius: 0;
 }
 .btn-group-horizontal .btn:last-child:not(:first-child) {
-  border-start-start-radius: 0;
-  border-start-end-radius: var(--rounded-btn, 0.5rem);
-  border-end-start-radius: 0;
-  border-end-end-radius: var(--rounded-btn, 0.5rem);
+  border-top-left-radius: 0;
+  border-top-right-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: var(--rounded-btn, 0.5rem);
 }
 .btn-group-vertical .btn:first-child:not(:last-child) {
   margin-top: -1px;
   margin-left: -0px;
-  border-start-start-radius: var(--rounded-btn, 0.5rem);
-  border-start-end-radius: var(--rounded-btn, 0.5rem);
-  border-end-start-radius: 0;
-  border-end-end-radius: 0;
+  border-top-left-radius: var(--rounded-btn, 0.5rem);
+  border-top-right-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 .btn-group-vertical .btn:last-child:not(:first-child) {
-  border-start-start-radius: 0;
-  border-start-end-radius: 0;
-  border-end-start-radius: var(--rounded-btn, 0.5rem);
-  border-end-end-radius: var(--rounded-btn, 0.5rem);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: var(--rounded-btn, 0.5rem);
+  border-bottom-right-radius: var(--rounded-btn, 0.5rem);
 }
 .card-compact .card-body {
   padding: 1rem;
@@ -3117,6 +3106,9 @@ html {
 .mx-auto {
   margin-left: auto;
   margin-right: auto;
+}
+.mr-1 {
+  margin-right: 0.25rem;
 }
 .mt-0 {
   margin-top: 0px;
@@ -3438,25 +3430,21 @@ html {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
-
 .hover\:opacity-100:hover {
   opacity: 1;
 }
-
 @media (min-width: 640px) {
 
   .sm\:max-w-\[300px\] {
     max-width: 300px;
   }
 }
-
 @media (min-width: 768px) {
 
   .md\:justify-end {
     justify-content: flex-end;
   }
 }
-
 @media (min-width: 1024px) {
 
   .lg\:flex-row-reverse {
@@ -3467,7 +3455,6 @@ html {
     text-align: left;
   }
 }
-
 @media (min-width: 1280px) {
 
   .xl\:max-w-\[900px\] {

--- a/tailwind.css
+++ b/tailwind.css
@@ -51,6 +51,10 @@
         @apply col-span-12 py-2;
     }
 
+    .stack-select {
+        min-width: 48px;
+    }
+
     .dataTables_filter {
         @apply flex justify-end;
     }


### PR DESCRIPTION
This should fix the stack selection for longer stack names.

Before:
![image](https://github.com/user-attachments/assets/d56f4ad3-068a-4c2a-9bf2-aab272174b19)

After:
![image](https://github.com/user-attachments/assets/794b14c6-2cca-47a4-8c57-eb483af7599f)

