### PR TITLE
Order spec objects in list by hash

### DIFF
--- a/generate_cache.py
+++ b/generate_cache.py
@@ -142,6 +142,7 @@ def write_cache_entries(name, specs, hash_stacks):
         metrics["versions"] = sorted(list(metrics["versions"]))
         metrics["compilers"] = sorted(list(metrics["compilers"]))
         metrics["stacks"] = sorted(list(metrics["stacks"]))
+        spec_details = sorted(spec_details, key=lambda obj: obj["hash"])
         render = template % (
             package_name,
             name,


### PR DESCRIPTION
After #17, the order of objects in the `spec-details` list is still non-deterministic.  Ordering those objects by the value stored in their `"hash"` key should further reduce the amount of meaningless diff committed and pushed every day.