### PR TITLE
Remove cache.spack.io CNAME record

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-cache.spack.io


### PR DESCRIPTION
This is needed so that https://github.com/spack/spack-cache can use this domain.